### PR TITLE
Fix issue when path has encoded URI elements.

### DIFF
--- a/dist/public/Stash Open Media Player.user.js
+++ b/dist/public/Stash Open Media Player.user.js
@@ -26,7 +26,7 @@
     const MIN_REQUIRED_PLUGIN_VERSION = '0.4.0';
 
     function openMediaPlayerTask(path) {
-        stash.runPluginTask("userscript_functions", "Open in Media Player", {"key":"path", "value":{"str": path}});
+        stash.runPluginTask("userscript_functions", "Open in Media Player", {"key":"path", "value":{"str": decodeURI(path)}});
     }
 
     // scene filepath open with Media Player

--- a/src/body/Stash Open Media Player.user.js
+++ b/src/body/Stash Open Media Player.user.js
@@ -13,7 +13,7 @@
     const MIN_REQUIRED_PLUGIN_VERSION = '0.4.0';
 
     function openMediaPlayerTask(path) {
-        stash.runPluginTask("userscript_functions", "Open in Media Player", {"key":"path", "value":{"str": path}});
+        stash.runPluginTask("userscript_functions", "Open in Media Player", {"key":"path", "value":{"str": decodeURI(path)}});
     }
 
     // scene filepath open with Media Player


### PR DESCRIPTION
I noticed a minor issue where the Open Media Player functionality did not work when the file path contained a space - the space was being passed to media player encoded as '%20'. The external media player then threw a file not found error due to the invalid path.

Added a simple call to decodeURI to decode space and other encoded path elements before it is passed to the media player. Confirmed working with both VLC and MPC.