### PR TITLE
Allow userscripts to work in subpath.

### DIFF
--- a/src/StashUserscriptLibrary.js
+++ b/src/StashUserscriptLibrary.js
@@ -270,7 +270,7 @@
                 }
 
                 try {
-                    const res = await unsafeWindow.fetch('/graphql', options);
+                    const res = await unsafeWindow.fetch(document.querySelector("head > base").href+'graphql', options);
                     this.log.debug(res);
                     return res.json();
                 }


### PR DESCRIPTION
Within [StashUserscriptLibrary.js](https://raw.githubusercontent.com/7dJx1qP/stash-userscripts/master/src/StashUserscriptLibrary.js), /graphql is hardcoded which prevents it from working in a subpath (ie: if a reverse proxy points to https://mydomain:1234/stash/ or https://mydomain:4321/apps/stash/). This causes calls to the graphql interface to throw a 404 error.

It should use the current base path as a part of that.  I have tested this both by accessing via IP address (ie: http://192.168.x.x:9999/) , in a root path (https://stashapp.mydomain.com:9999), in a subpath (https://apps.mydomain.com:9999/stash/ ).

document.querySelector("head > base").href appears to work in all cases and returns correctly.  This is because stash sets `<base href="/stash/">` or `<base href="/">` as per its configuration.  Note that if that behaviour ever changes in stash, this code would need to be updated.  Currently, it expands to the correct path to graphql.